### PR TITLE
Add install of required module in serial_sendfile

### DIFF
--- a/binary/serial_sendfile.py
+++ b/binary/serial_sendfile.py
@@ -1,7 +1,11 @@
 import sys
-import serial
-
-# pip install pyserial
+import subprocess
+try:
+    import serial
+except ImportError:
+    print("Installing serial")
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "pyserial"])
+    import serial
 
 port = "/dev/ttyUSB1"
 


### PR DESCRIPTION
안녕하세요, 오픈소스 기여에 관심이 있어서 소개를 듣고 제가 조금이라도 기여할 수 있는 부분이 없나 살펴보다가 수정해보았습니다. Python 코드에 적어주신 주석을 보니 pip install 을 수동으로 쳐야되는 것처럼 보여서 설치가 되어있지 않으면 자동으로 설치되도록 하는 코드를 추가해보았습니다. 필요 없는 코드이거나, 코드 내용에 수정을 원하신다면 많은 피드백 부탁드립니다. 좋은 오픈소스 운영해주셔서 감사합니다!

Hello all,
I have been interested in contributing to this open source after learning about your project, I looked into areas where I might be able to make a small contribution. I noticed that the Python code comments suggested manually running pip install, so I updated the code to automatically handle installation if the required module is missing.

If the code is unnecessary or if you would like any adjustments to the implementation, I would greatly appreciate your feedback. Thank you for maintaining such a great open-source project!